### PR TITLE
Update CMakeLists.txt and quick-start.sh: change target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,10 @@ add_eyrie_runtime(${eapp_bin}-eyrie
   ${eyrie_plugins}
   ${eyrie_files_to_copy})
 
-add_keystone_package(package
+add_keystone_package(packagedemo
   ${package_name}
   ${package_script}
   ${eyrie_files_to_copy} server_eapp/server_eapp.eapp_riscv ${host_bin})
 
-add_dependencies(package ${eapp_bin}-eyrie)
+add_dependencies(packagedemo ${eapp_bin}-eyrie)
 

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -85,7 +85,7 @@ mkdir -p build
 cd build
 cmake ..
 make
-make package
+make packagedemo
 
 # Done!
 echo -e "************ Demo binaries built and copied into overlay directory. ***************


### PR DESCRIPTION
Thanks to @jctullos that propose a solution in an open issue " #16 ". This fix does not solve completely the open issue. 

It fix the following error:
`CMake Error at /keystone/sdk/build64/cmake/macros.cmake:126 (add_custom_target):
  The target name "package" is reserved or not valid for certain CMake
  features, such as generator expressions, and may result in undefined
  behavior.
Call Stack (most recent call first):
  CMakeLists.txt:78 (add_keystone_package)


CMake Error at CMakeLists.txt:83 (add_dependencies):
  Cannot add target-level dependencies to non-existent target "package".`
